### PR TITLE
Use fst crate for improved performance

### DIFF
--- a/process_corpus/Cargo.toml
+++ b/process_corpus/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+fst = "0.4"

--- a/search_corpus/Cargo.toml
+++ b/search_corpus/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 cgi = "0.6"
 json = "0.12"
 url = "2.1"
+fst = "0.4"
+regex-automata = { version = "0.1.9", features = ["transducer"] }
+memmap = "0.7"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/search_corpus/src/lib.rs
+++ b/search_corpus/src/lib.rs
@@ -76,6 +76,7 @@ fn validate_absent_letters(absent_letters: &str) -> Result<(), String> {
 
 
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
After investigating the [fst crate](https://github.com/BurntSushi/fst) suggested in #1, I was able to get much improved performance in some cases.

These benchmarks were taken on my desktop computer:

&nbsp;|without FST|with FST|
--|--|--|
small_word_many_options| 39 ms | 7 ms (-81%)|
small_word_few_options| 37 ms | 199 **u**s (-99%!) |
long_word_many_options| 53 ms | 72 ms (+34%) |
long_word_few_options| 38 ms | 351 **u**s (-99%!) |

So the FST implementation is much faster until there are 6 or more question marks in the pattern, at which point it becomes slower. This implementation uses a hybrid approach - if there are less than 6 question marks, it uses the FST, otherwise is does the old regular-expression matching on the word list.